### PR TITLE
adding --run flag

### DIFF
--- a/s3_content_type_fixer.py
+++ b/s3_content_type_fixer.py
@@ -73,7 +73,7 @@ def main():
 
     # Start the workers
     for _ in xrange(args.workers):
-        p = multiprocessing.Process(target=check_headers, args=(bucket, queue, args.verbose),)
+        p = multiprocessing.Process(target=check_headers, args=(bucket, queue, args.verbose, args.run),)
         p.start()
         processes.append(p)
     

--- a/s3_content_type_fixer.py
+++ b/s3_content_type_fixer.py
@@ -18,7 +18,7 @@ def get_bucket(access_key, secret_key, bucket):
     """Gets an S3 bucket"""
     return S3Connection(access_key, secret_key).get_bucket(bucket)
 
-def check_headers(bucket, queue, verbose):
+def check_headers(bucket, queue, verbose, run):
     """
     Callback used by sub-processes to check the headers of candidate files in
     a multiprocessing queue
@@ -50,8 +50,10 @@ def check_headers(bucket, queue, verbose):
             if verbose:
                 print "%s: Matches expected content type" % key.name
         else:
-            print "%s: Current content type (%s) does not match expected (%s); fixing" % (key.name, content_type, expected_content_type)
-            key.copy(key.bucket, key.name, preserve_acl=True, metadata={'Content-Type': expected_content_type, 'Content-Disposition': key.content_disposition})
+            print "%s: Current content type (%s) does not match expected (%s); " % (key.name, content_type, expected_content_type)
+            if run:
+                print "fixing..."
+                key.copy(key.bucket, key.name, preserve_acl=True, metadata={'Content-Type': expected_content_type, 'Content-Disposition': key.content_disposition})
 
 def main():
     parser = argparse.ArgumentParser(description="Fixes the content-type of assets on S3")
@@ -62,6 +64,7 @@ def main():
     parser.add_argument("--prefixes", "-p", type=str, default=[""], required=False, nargs="*", help="File path prefixes to check")
     parser.add_argument("--workers", "-w", type=int, default=4, required=False, help="The number of workers")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument("--run", "-r", action="store_true", help="Run instead of test")
 
     args = parser.parse_args()
     queue = multiprocessing.Queue()


### PR DESCRIPTION
changing default behavior to only list the files that are problematic. use --run or -r to actually run the fix. This is very useful when fixing production environment and you want to know which files the tool will fix.