### PR TITLE
Fix Issue #6: Don't set disposition to 'None'

### DIFF
--- a/s3_content_type_fixer.py
+++ b/s3_content_type_fixer.py
@@ -51,7 +51,10 @@ def check_headers(bucket, queue, verbose):
                 print "%s: Matches expected content type" % key.name
         else:
             print "%s: Current content type (%s) does not match expected (%s); fixing" % (key.name, content_type, expected_content_type)
-            key.copy(key.bucket, key.name, preserve_acl=True, metadata={'Content-Type': expected_content_type, 'Content-Disposition': key.content_disposition})
+            metadata = {'Content-Type': expected_content_type}
+            if key.content_disposition is not None:
+                metadata['Content-Disposition'] = key.content_disposition
+            key.copy(key.bucket, key.name, preserve_acl=True, metadata=metadata)
 
 def main():
     parser = argparse.ArgumentParser(description="Fixes the content-type of assets on S3")


### PR DESCRIPTION
If your S3 object didn't have an explicit content disposition, boto
returns a python None. If you then set that on the copied S3 object,
it actually sets the header value to the string 'None'.